### PR TITLE
Support for AWS STS keys

### DIFF
--- a/Dotnet core console app/AwsIOTMqttOverWebsockets/AwsIOTMqttOverWebsockets/Messaging/CloudConnector.cs
+++ b/Dotnet core console app/AwsIOTMqttOverWebsockets/AwsIOTMqttOverWebsockets/Messaging/CloudConnector.cs
@@ -31,7 +31,8 @@ namespace AwsIOTMqttOverWebsockets.Messaging
                     Host = cloudConnectionConfig.Host,
                     Region = cloudConnectionConfig.Region,
                     AccessKey = cloudConnectionConfig.AccessKey,
-                    SecretKey = cloudConnectionConfig.SecretKey
+                    SecretKey = cloudConnectionConfig.SecretKey,
+                    SessionToken = cloudConnectionConfig.SessionToken
                 };
 
                 string signedRequestUrl = awsMqttConnection.SignRequestUrl();

--- a/Dotnet core console app/AwsIOTMqttOverWebsockets/AwsIOTMqttOverWebsockets/Model/AwsMqttConnection.cs
+++ b/Dotnet core console app/AwsIOTMqttOverWebsockets/AwsIOTMqttOverWebsockets/Model/AwsMqttConnection.cs
@@ -10,6 +10,7 @@ namespace AwsIOTMqttOverWebsockets.Model
         public string Region { get; set; }
         public string AccessKey { get; set; }
         public string SecretKey { get; set; }
+        public string SessionToken { get; set; }
 
         public string SignRequestUrl()
         {
@@ -29,7 +30,8 @@ namespace AwsIOTMqttOverWebsockets.Model
                                                         string.Empty,
                                                         AWS4SignerBase.EMPTY_BODY_SHA256,
                                                         this.AccessKey,
-                                                        this.SecretKey);
+                                                        this.SecretKey,
+                                                        this.SessionToken);
 
             var signedRequestBuilder = new UriBuilder(endpointBuilder.Uri);
             signedRequestBuilder.Query = authorization;

--- a/Dotnet core console app/AwsIOTMqttOverWebsockets/AwsIOTMqttOverWebsockets/Model/CloudConnectionConfig.cs
+++ b/Dotnet core console app/AwsIOTMqttOverWebsockets/AwsIOTMqttOverWebsockets/Model/CloudConnectionConfig.cs
@@ -45,5 +45,13 @@ namespace AwsIOTMqttOverWebsockets.Model
                 return ConfigHelper.ReadSetting("secretkey");
             }
         }
+
+        public string SessionToken
+        {
+            get
+            {
+                return ConfigHelper.ReadSetting("sessiontoken");
+            }
+        }
     }
 }

--- a/Dotnet core console app/AwsIOTMqttOverWebsockets/AwsIOTMqttOverWebsockets/Signers/AWS4SignerBase.cs
+++ b/Dotnet core console app/AwsIOTMqttOverWebsockets/AwsIOTMqttOverWebsockets/Signers/AWS4SignerBase.cs
@@ -33,6 +33,7 @@ namespace AwsIOTMqttOverWebsockets.Signers
         public const string X_Amz_Content_SHA256 = "X-Amz-Content-SHA256";
         public const string X_Amz_Decoded_Content_Length = "X-Amz-Decoded-Content-Length";
         public const string X_Amz_Meta_UUID = "X-Amz-Meta-UUID";
+        public const string X_Amz_Security_Token = "X-Amz-Security-Token";
 
         // the name of the keyed hash algorithm used in signing
         public const string HMACSHA256 = "HMACSHA256";

--- a/Dotnet core console app/AwsIOTMqttOverWebsockets/AwsIOTMqttOverWebsockets/appsettings.json
+++ b/Dotnet core console app/AwsIOTMqttOverWebsockets/AwsIOTMqttOverWebsockets/appsettings.json
@@ -2,5 +2,6 @@
   "host": "yourendpoint.iot.us-east-1.amazonaws.com",
   "region": "us-east-1",
   "accesskey": "youraccesskey",
-  "secretkey": "yoursecretkey"
+  "secretkey": "yoursecretkey",
+  "sessiontoken": "yoursessiontoken"
 }


### PR DESCRIPTION
Added support for AWS STS keys. Session key obtained from STS service can be set in appsettings.json

*Issue #, if available:*
Keys generated using AWS STS (Security Token Service) is not supported

*Description of changes:*
Added ability to add session token in appsettings.json, included session token in Authorization.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
